### PR TITLE
fix iterator of Function map

### DIFF
--- a/ch8.md
+++ b/ch8.md
@@ -74,9 +74,9 @@ To implement `map(..)`:
 function map(mapperFn,arr) {
 	var newList = [];
 
-	for (let idx = 0; i < arr.length; i++) {
+	for (let i = 0; i < arr.length; i++) {
 		newList.push(
-			mapperFn( arr[i], idx, arr )
+			mapperFn( arr[i], i, arr )
 		);
 	}
 


### PR DESCRIPTION
Perhaps I'm missing a purpose here, but I figure `idx` was declare but then "I" was later used as the iterator.

**Yes, I promise I've read the [Contributions Guidelines](https://github.com/getify/Functional-Light-JS/blob/master/CONTRIBUTING.md)** (please feel free to remove this line *IF YOU ACTUALLY READ THEM*).
